### PR TITLE
sbbf: add backwards compatibility to sbbf02 in addition to sbbf02

### DIFF
--- a/starbound/sbbf02.py
+++ b/starbound/sbbf02.py
@@ -86,7 +86,8 @@ class FileSBBF02(filebase.File):
         super(FileSBBF02, self).initialize()
         stream = self._stream
 
-        assert stream.read(6) == b'SBBF03', 'Invalid file format'
+        header = stream.read(6)
+        assert (header  == b'SBBF02' or header  == b'SBBF03'), 'Invalid file format'
 
         # Block header data.
         fields = struct.unpack('>ii?i', stream.read(13))


### PR DESCRIPTION
This is the current implementation used by starcheat (wizzomafizzo@591e2bd) to guarantee compatibility with sbbf02 mods which are still supported by recent starbound versions.