### PR TITLE
Tile data updated to 31 bytes in length.

### DIFF
--- a/FORMATS.md
+++ b/FORMATS.md
@@ -236,6 +236,7 @@ A single tile is made up of 30 bytes of binary data:
 | 17       | 28    | `uint8`  | "Biome"⁴
 | 18       | 29    | `uint8`  | "Environment Biome"⁴
 | 19       | 30    | `bool`   | Indestructible (tree/vine base)
+| 20       | 31    | `unknown`| Unknown?
 
 ¹ Refers to a material by its id. Additional constants:
 

--- a/starbound/__init__.py
+++ b/starbound/__init__.py
@@ -50,8 +50,7 @@ Tile = namedtuple('Tile', [
     'dungeon_id',
     'biome',
     'biome_2',
-    'indestructible',
-    'unknown'
+    'indestructible'
 ])
 
 

--- a/starbound/__init__.py
+++ b/starbound/__init__.py
@@ -51,6 +51,7 @@ Tile = namedtuple('Tile', [
     'biome',
     'biome_2',
     'indestructible',
+    'unknown'
 ])
 
 
@@ -90,7 +91,7 @@ class World(BTreeDB5):
 
     @classmethod
     def read_tile(cls, stream):
-        values = struct.unpack('>hBBhBhBBhBBffBBHBB?', stream.read(30))
+        values = struct.unpack('>hBBhBhBBhBBffBBHBB?x', stream.read(31))
         return Tile(*values)
 
 


### PR DESCRIPTION
Not sure what the 31st byte is used for at this time.  It could
be a new field, or the new field may have been added in the
middle, shifting the others over (though that doesn't seem to
be the case)