### PR TITLE
Functions in BTreeDB5 and World to support getting a list of all regions

### DIFF
--- a/starbound/__init__.py
+++ b/starbound/__init__.py
@@ -93,6 +93,17 @@ class World(BTreeDB5):
         values = struct.unpack('>hBBhBhBBhBBffBBHBB?x', stream.read(31))
         return Tile(*values)
 
+    def get_all_regions_with_tiles(self):
+        """
+        Returns a set of (rx, ry) tuples which describes all regions for
+        which the world has tile data
+        """
+        regions = set()
+        for key in self.get_all_keys():
+            (layer, rx, ry) = struct.unpack('>BHH', key)
+            if layer == 1:
+                regions.add((rx, ry))
+        return regions
 
 def read_sbvj01(stream):
     assert stream.read(6) == b'SBVJ01', 'Invalid header'

--- a/starbound/__init__.py
+++ b/starbound/__init__.py
@@ -95,15 +95,13 @@ class World(BTreeDB5):
 
     def get_all_regions_with_tiles(self):
         """
-        Returns a set of (rx, ry) tuples which describes all regions for
-        which the world has tile data
+        Generator which yields a set of (rx, ry) tuples which describe
+        all regions for which the world has tile data
         """
-        regions = set()
         for key in self.get_all_keys():
             (layer, rx, ry) = struct.unpack('>BHH', key)
             if layer == 1:
-                regions.add((rx, ry))
-        return regions
+                yield (rx, ry)
 
 def read_sbvj01(stream):
     assert stream.read(6) == b'SBVJ01', 'Invalid header'


### PR DESCRIPTION
Not sure how you'll feel about this one, but I wanted to be able to get a list of all regions in world files which have tile data, so I added two functions to my local checkout:

1) `BTreeDB5.get_all_keys` - Recursive function which returns a list of all (binary) keys in the tree
2) `World.get_all_regions_with_tiles` - Loops through the above and constructs a set of all valid regions

Seems to work a treat, or at least it's worked well on the small handful of worlds I've tried it on so far.